### PR TITLE
Add support for toggling comments

### DIFF
--- a/scoped-properties/language-toml.cson
+++ b/scoped-properties/language-toml.cson
@@ -1,0 +1,3 @@
+'.source.toml':
+  'editor':
+    'commentStart': '# '


### PR DESCRIPTION
Right now the comments when using `editor:toggle-line-comments` `/* */` is used.

It should be https://github.com/mojombo/toml#comment

The grammar for comments is correct.
