### PR TITLE
Add License field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.15.0",
   "description": "Syntax highlighting for Tom's Obvious, Minimal Language (TOML).",
   "repository": "https://github.com/atom/language-toml",
+  "license": "MIT",
   "engines": {
     "atom": "*"
   }


### PR DESCRIPTION
Add license field to `package.json` per https://github.com/atom/atom/pull/6645. :page_facing_up: 