### PR TITLE
fixed dates, numbers and strings

### DIFF
--- a/grammars/toml.cson
+++ b/grammars/toml.cson
@@ -3,35 +3,68 @@
 'fileTypes': ['toml']
 'patterns': [
   {
-    'match': '(?:^\\s*)(\\[\\[([^\\]]+)\\]\\])'
+    'match': '(?:^\\s*)((\\[\\[)[^\\]]+(\\]\\]))'
     'captures':
-      '2': 'name': 'variable.keygroup.array.toml'
-    'name': 'keygroup.toml'
+      '1': 'name': 'entity.name.section.table.array.toml'
+      '2': 'name': 'punctuation.definition.table.array.begin.toml'
+      '3': 'name': 'punctuation.definition.table.array.end.toml'
   }
   {
-    'match': '(?:^\\s*)(\\[([^\\]]+)\\])'
+    'match': '(?:^\\s*)((\\[)[^\\]]+(\\]))'
     'captures':
-      '2': 'name': 'variable.keygroup.toml'
-    'name': 'keygroup.toml'
+      '1': 'name': 'entity.name.section.table.toml'
+      '2': 'name': 'punctuation.definition.table.begin.toml'
+      '3': 'name': 'punctuation.definition.table.end.toml'
   }
   {
-    'match': '(?:^\\s*)(\\S+)\\s*='
+    'match': '(?:^\\s*)(\\S+)\\s*(=)'
     'captures':
-      '1': 'name': 'entity.key.toml'
-    'name': 'key.toml'
+      '1': 'name': 'variable.other.key.toml'
+      '2': 'name': 'keyword.operator.assign.toml'
+  }
+  {
+    'begin': '"""'
+    'beginCaptures':
+      '0': 'name': 'punctuation.definition.string.begin.toml'
+    'end': '"""'
+    'endCaptures':
+      '0': 'name': 'punctuation.definition.string.end.toml'
+    'name': 'string.quoted.double.block.toml'
+    'patterns': [
+      'match': '\\\\[btnfr"\\\\]|\\\\u[A-Fa-f0-9]{4}|\\\\U[A-Fa-f0-9]{8}|\\\\$'
+      'name': 'constant.character.escape.toml'
+    ]
+  }
+  {
+    'begin': "'''"
+    'beginCaptures':
+      '0': 'name': 'punctuation.definition.string.begin.toml'
+    'end': "'''"
+    'endCaptures':
+      '0': 'name': 'punctuation.definition.string.end.toml'
+    'name': 'string.quoted.single.block.toml'
   }
   {
     'begin': '"'
     'beginCaptures':
-      '0': 'name': 'string.begin.toml'
+      '0': 'name': 'punctuation.definition.string.begin.toml'
     'end': '"'
     'endCaptures':
-      '0': 'name': 'string.end.toml'
-    'name': 'string.toml'
+      '0': 'name': 'punctuation.definition.string.end.toml'
+    'name': 'string.quoted.double.toml'
     'patterns': [
-      'match': '\\\\[nt0r"\\\\]'
-      'name' : 'constant.character.escape.toml'
+      'match': '\\\\[btnfr"\\\\]|\\\\u[A-Fa-f0-9]{4}|\\\\U[A-Fa-f0-9]{8}'
+      'name': 'constant.character.escape.toml'
     ]
+  }
+  {
+    'begin': "'"
+    'beginCaptures':
+      '0': 'name': 'punctuation.definition.string.begin.toml'
+    'end': "'"
+    'endCaptures':
+      '0': 'name': 'punctuation.definition.string.end.toml'
+    'name': 'string.quoted.single.toml'
   }
   {
     'match': '#.*$'
@@ -46,11 +79,15 @@
     'name': 'constant.language.boolean.false.toml'
   }
   {
-    'match': '\\d{4}-\\d{2}-\\d{2}(T)\\d{2}:\\d{2}:\\d{2}(Z)'
-    'name': 'support.date.toml'
+    'match': '\\d{4}-\\d{2}-\\d{2}(?:(T)\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:(Z)|([+-])\\d{2}:\\d{2})?)?'
+    'name': 'constant.numeric.date.toml'
+    'captures':
+      '1': 'name': 'keyword.other.time.toml'
+      '2': 'name': 'keyword.other.offset.toml'
+      '3': 'name': 'keyword.other.offset.toml'
   }
   {
-    'match': '-?\\d+(\\.?\\d+)?'
+    'match': '[+-]?(0|[1-9]\\d*)(_\\d+)*((\\.\\d+)(_\\d+)*)?([eE][+-]?\\d+(_\\d+)*)?'
     'name': 'constant.numeric.toml'
   }
 ]

--- a/spec/toml-spec.coffee
+++ b/spec/toml-spec.coffee
@@ -18,53 +18,96 @@ describe "TOML grammar", ->
 
   it "tokenizes strings", ->
     {tokens} = grammar.tokenizeLine('"I am a string"')
-    expect(tokens[0]).toEqual value: '"', scopes: ["source.toml", "string.toml", "string.begin.toml"]
-    expect(tokens[1]).toEqual value: 'I am a string', scopes: ["source.toml", "string.toml"]
-    expect(tokens[2]).toEqual value: '"', scopes: ["source.toml", "string.toml", "string.end.toml"]
+    expect(tokens[0]).toEqual value: '"', scopes: ["source.toml", "string.quoted.double.toml", "punctuation.definition.string.begin.toml"]
+    expect(tokens[1]).toEqual value: 'I am a string', scopes: ["source.toml", "string.quoted.double.toml"]
+    expect(tokens[2]).toEqual value: '"', scopes: ["source.toml", "string.quoted.double.toml", "punctuation.definition.string.end.toml"]
 
     {tokens} = grammar.tokenizeLine('"I\'m \\n escaped"')
-    expect(tokens[0]).toEqual value: '"', scopes: ["source.toml", "string.toml", "string.begin.toml"]
-    expect(tokens[1]).toEqual value: "I'm ", scopes: ["source.toml", "string.toml"]
-    expect(tokens[2]).toEqual value: "\\n", scopes: ["source.toml", "string.toml", "constant.character.escape.toml"]
-    expect(tokens[3]).toEqual value: " escaped", scopes: ["source.toml", "string.toml"]
-    expect(tokens[4]).toEqual value: '"', scopes: ["source.toml", "string.toml", "string.end.toml"]
+    expect(tokens[0]).toEqual value: '"', scopes: ["source.toml", "string.quoted.double.toml", "punctuation.definition.string.begin.toml"]
+    expect(tokens[1]).toEqual value: "I'm ", scopes: ["source.toml", "string.quoted.double.toml"]
+    expect(tokens[2]).toEqual value: "\\n", scopes: ["source.toml", "string.quoted.double.toml", "constant.character.escape.toml"]
+    expect(tokens[3]).toEqual value: " escaped", scopes: ["source.toml", "string.quoted.double.toml"]
+    expect(tokens[4]).toEqual value: '"', scopes: ["source.toml", "string.quoted.double.toml", "punctuation.definition.string.end.toml"]
+
+    {tokens} = grammar.tokenizeLine("'I am not \\n escaped'")
+    expect(tokens[0]).toEqual value: "'", scopes: ["source.toml", "string.quoted.single.toml", "punctuation.definition.string.begin.toml"]
+    expect(tokens[1]).toEqual value: 'I am not \\n escaped', scopes: ["source.toml", "string.quoted.single.toml"]
+    expect(tokens[2]).toEqual value: "'", scopes: ["source.toml", "string.quoted.single.toml", "punctuation.definition.string.end.toml"]
+
+  it "tokenizes multiline strings", ->
+    lines = grammar.tokenizeLines '''
+      """
+      I am a\\
+      string
+      """
+    '''
+    expect(lines[0][0]).toEqual value: '"""', scopes: ["source.toml", "string.quoted.double.block.toml", "punctuation.definition.string.begin.toml"]
+    expect(lines[1][0]).toEqual value: 'I am a', scopes: ["source.toml", "string.quoted.double.block.toml"]
+    expect(lines[1][1]).toEqual value: '\\', scopes: ["source.toml", "string.quoted.double.block.toml", "constant.character.escape.toml"]
+    expect(lines[2][0]).toEqual value: 'string', scopes: ["source.toml", "string.quoted.double.block.toml"]
+    expect(lines[3][0]).toEqual value: '"""', scopes: ["source.toml", "string.quoted.double.block.toml", "punctuation.definition.string.end.toml"]
+
+    lines = grammar.tokenizeLines """
+      '''
+      I am a\\
+      string
+      '''
+    """
+    expect(lines[0][0]).toEqual value: "'''", scopes: ["source.toml", "string.quoted.single.block.toml", "punctuation.definition.string.begin.toml"]
+    expect(lines[1][0]).toEqual value: 'I am a\\', scopes: ["source.toml", "string.quoted.single.block.toml"]
+    expect(lines[2][0]).toEqual value: 'string', scopes: ["source.toml", "string.quoted.single.block.toml"]
+    expect(lines[3][0]).toEqual value: "'''", scopes: ["source.toml", "string.quoted.single.block.toml", "punctuation.definition.string.end.toml"]
 
   it "tokenizes booleans", ->
     {tokens} = grammar.tokenizeLine("true")
     expect(tokens[0]).toEqual value: "true", scopes: ["source.toml", "constant.language.boolean.true.toml"]
+
     {tokens} = grammar.tokenizeLine("false")
     expect(tokens[0]).toEqual value: "false", scopes: ["source.toml", "constant.language.boolean.false.toml"]
 
-  it "tokenizes numbers", ->
-    {tokens} = grammar.tokenizeLine("123")
-    expect(tokens[0]).toEqual value: "123", scopes: ["source.toml", "constant.numeric.toml"]
+  it "tokenizes integers", ->
+    for int in ["+99", "42", "0", "-17", "1_000", "1_2_3_4_5"]
+      {tokens} = grammar.tokenizeLine(int)
+      expect(tokens[0]).toEqual value: int, scopes: ["source.toml", "constant.numeric.toml"]
 
-    {tokens} = grammar.tokenizeLine("-1")
-    expect(tokens[0]).toEqual value: "-1", scopes: ["source.toml", "constant.numeric.toml"]
-
-    {tokens} = grammar.tokenizeLine("3.14")
-    expect(tokens[0]).toEqual value: "3.14", scopes: ["source.toml", "constant.numeric.toml"]
-
-    {tokens} = grammar.tokenizeLine("-123.456")
-    expect(tokens[0]).toEqual value: "-123.456", scopes: ["source.toml", "constant.numeric.toml"]
+  it "tokenizes floats", ->
+    for float in ["+1.0", "3.1415", "-0.01", "5e+22", "1e6", "-2E-2", "6.626e-34", "6.626e-34", "9_224_617.445_991_228_313", "1e1_000"]
+      {tokens} = grammar.tokenizeLine(float)
+      expect(tokens[0]).toEqual value: float, scopes: ["source.toml", "constant.numeric.toml"]
 
   it "tokenizes dates", ->
     {tokens} = grammar.tokenizeLine("1979-05-27T07:32:00Z")
-    expect(tokens[0]).toEqual value: "1979-05-27T07:32:00Z", scopes: ["source.toml", "support.date.toml"]
+    expect(tokens[0]).toEqual value: "1979-05-27", scopes: ["source.toml", "constant.numeric.date.toml"]
+    expect(tokens[1]).toEqual value: "T", scopes: ["source.toml", "constant.numeric.date.toml", "keyword.other.time.toml"]
+    expect(tokens[2]).toEqual value: "07:32:00", scopes: ["source.toml", "constant.numeric.date.toml"]
+    expect(tokens[3]).toEqual value: "Z", scopes: ["source.toml", "constant.numeric.date.toml", "keyword.other.offset.toml"]
+    
+    {tokens} = grammar.tokenizeLine("1979-05-27T00:32:00.999999-07:00")
+    expect(tokens[0]).toEqual value: "1979-05-27", scopes: ["source.toml", "constant.numeric.date.toml"]
+    expect(tokens[1]).toEqual value: "T", scopes: ["source.toml", "constant.numeric.date.toml", "keyword.other.time.toml"]
+    expect(tokens[2]).toEqual value: "00:32:00.999999", scopes: ["source.toml", "constant.numeric.date.toml"]
+    expect(tokens[3]).toEqual value: "-", scopes: ["source.toml", "constant.numeric.date.toml", "keyword.other.offset.toml"]
+    expect(tokens[4]).toEqual value: "07:00", scopes: ["source.toml", "constant.numeric.date.toml"]
 
-  it "tokenizes keygroups", ->
-    {tokens} = grammar.tokenizeLine("[keygroup]")
-    expect(tokens[0]).toEqual value: "[", scopes: ["source.toml", "keygroup.toml"]
-    expect(tokens[1]).toEqual value: "keygroup", scopes: ["source.toml", "keygroup.toml", "variable.keygroup.toml"]
-    expect(tokens[2]).toEqual value: "]", scopes: ["source.toml", "keygroup.toml"]
+  it "tokenizes tables", ->
+    {tokens} = grammar.tokenizeLine("[table]")
+    expect(tokens[0]).toEqual value: "[", scopes: ["source.toml", "entity.name.section.table.toml", "punctuation.definition.table.begin.toml"]
+    expect(tokens[1]).toEqual value: "table", scopes: ["source.toml", "entity.name.section.table.toml"]
+    expect(tokens[2]).toEqual value: "]", scopes: ["source.toml", "entity.name.section.table.toml", "punctuation.definition.table.end.toml"]
 
-  it "tokenizes keygroup arrays", ->
-    {tokens} = grammar.tokenizeLine("[[keygroup]]")
-    expect(tokens[0]).toEqual value: "[[", scopes: ["source.toml", "keygroup.toml"]
-    expect(tokens[1]).toEqual value: "keygroup", scopes: ["source.toml", "keygroup.toml", "variable.keygroup.array.toml"]
-    expect(tokens[2]).toEqual value: "]]", scopes: ["source.toml", "keygroup.toml"]
+    {tokens} = grammar.tokenizeLine("  [table]")
+    expect(tokens[0]).toEqual value: "  ", scopes: ["source.toml"]
+    expect(tokens[1]).toEqual value: "[", scopes: ["source.toml", "entity.name.section.table.toml", "punctuation.definition.table.begin.toml"]
+    # and so on
+
+  it "tokenizes table arrays", ->
+    {tokens} = grammar.tokenizeLine("[[table]]")
+    expect(tokens[0]).toEqual value: "[[", scopes: ["source.toml", "entity.name.section.table.array.toml", "punctuation.definition.table.array.begin.toml"]
+    expect(tokens[1]).toEqual value: "table", scopes: ["source.toml", "entity.name.section.table.array.toml"]
+    expect(tokens[2]).toEqual value: "]]", scopes: ["source.toml", "entity.name.section.table.array.toml", "punctuation.definition.table.array.end.toml"]
 
   it "tokenizes keys", ->
     {tokens} = grammar.tokenizeLine("key =")
-    expect(tokens[0]).toEqual value: "key", scopes: ["source.toml", "key.toml", "entity.key.toml"]
-    expect(tokens[1]).toEqual value: " =", scopes: ["source.toml", "key.toml"]
+    expect(tokens[0]).toEqual value: "key", scopes: ["source.toml", "variable.other.key.toml"]
+    expect(tokens[1]).toEqual value: " ", scopes: ["source.toml"]
+    expect(tokens[2]).toEqual value: "=", scopes: ["source.toml", "keyword.operator.assign.toml"]


### PR DESCRIPTION
now supports

* all kinds of dates, not only UTC dates with time and without microseconds
* single-quoted strings and multiline strings
* scientific notation and underscores in floats

fixes #6 