### PR TITLE
Fix greedy key capturing

### DIFF
--- a/grammars/toml.cson
+++ b/grammars/toml.cson
@@ -23,10 +23,28 @@
       '3': 'name': 'punctuation.definition.table.end.toml'
   }
   {
-    'match': '(?:^\\s*)(\\S+)\\s*(=)'
+    'match': '([A-Za-z0-9_-]+)\\s*(=)' # IMPORTANT: Do not replace with [\\w-].  \\w includes more than just a-z.
     'captures':
       '1': 'name': 'variable.other.key.toml'
-      '2': 'name': 'keyword.operator.assign.toml'
+      '2': 'name': 'keyword.operator.assignment.toml'
+  }
+  {
+    'match': '((")([\\w\\s-]*)("))\\s*(=)' # We use \\w here because quoted keys allow for a much wider variety.
+    'captures':
+      '1': 'name': 'string.quoted.double.toml'
+      '2': 'name': 'punctuation.definition.string.begin.toml'
+      '3': 'name': 'variable.other.key.toml'
+      '4': 'name': 'punctuation.definition.string.end.toml'
+      '5': 'name': 'keyword.operator.assignment.toml'
+  }
+  {
+    'match': "((')([\\w\\s-]*)('))\\s*(=)" # We use \\w here because quoted keys allow for a much wider variety.
+    'captures':
+      '1': 'name': 'string.quoted.single.toml'
+      '2': 'name': 'punctuation.definition.string.begin.toml'
+      '3': 'name': 'variable.other.key.toml'
+      '4': 'name': 'punctuation.definition.string.end.toml'
+      '5': 'name': 'keyword.operator.assignment.toml'
   }
   {
     'begin': '"""'

--- a/spec/toml-spec.coffee
+++ b/spec/toml-spec.coffee
@@ -25,6 +25,10 @@ describe "TOML grammar", ->
     expect(tokens[0]).toEqual value: "#", scopes: ["source.toml", "comment.line.number-sign.toml", "punctuation.definition.comment.toml"]
     expect(tokens[1]).toEqual value: "Nope = still a comment", scopes: ["source.toml", "comment.line.number-sign.toml"]
 
+    {tokens} = grammar.tokenizeLine(" #Whitespace = tricky")
+    expect(tokens[1]).toEqual value: "#", scopes: ["source.toml", "comment.line.number-sign.toml", "punctuation.definition.comment.toml"]
+    expect(tokens[2]).toEqual value: "Whitespace = tricky", scopes: ["source.toml", "comment.line.number-sign.toml"]
+
   it "tokenizes strings", ->
     {tokens} = grammar.tokenizeLine('"I am a string"')
     expect(tokens[0]).toEqual value: '"', scopes: ["source.toml", "string.quoted.double.toml", "punctuation.definition.string.begin.toml"]
@@ -42,6 +46,11 @@ describe "TOML grammar", ->
     expect(tokens[0]).toEqual value: "'", scopes: ["source.toml", "string.quoted.single.toml", "punctuation.definition.string.begin.toml"]
     expect(tokens[1]).toEqual value: 'I am not \\n escaped', scopes: ["source.toml", "string.quoted.single.toml"]
     expect(tokens[2]).toEqual value: "'", scopes: ["source.toml", "string.quoted.single.toml", "punctuation.definition.string.end.toml"]
+
+    {tokens} = grammar.tokenizeLine('"Equal sign ahead = no problem"')
+    expect(tokens[0]).toEqual value: '"', scopes: ["source.toml", "string.quoted.double.toml", "punctuation.definition.string.begin.toml"]
+    expect(tokens[1]).toEqual value: 'Equal sign ahead = no problem', scopes: ["source.toml", "string.quoted.double.toml"]
+    expect(tokens[2]).toEqual value: '"', scopes: ["source.toml", "string.quoted.double.toml", "punctuation.definition.string.end.toml"]
 
   it "tokenizes multiline strings", ->
     lines = grammar.tokenizeLines '''
@@ -119,4 +128,70 @@ describe "TOML grammar", ->
     {tokens} = grammar.tokenizeLine("key =")
     expect(tokens[0]).toEqual value: "key", scopes: ["source.toml", "variable.other.key.toml"]
     expect(tokens[1]).toEqual value: " ", scopes: ["source.toml"]
-    expect(tokens[2]).toEqual value: "=", scopes: ["source.toml", "keyword.operator.assign.toml"]
+    expect(tokens[2]).toEqual value: "=", scopes: ["source.toml", "keyword.operator.assignment.toml"]
+
+    {tokens} = grammar.tokenizeLine("1key_-34 =")
+    expect(tokens[0]).toEqual value: "1key_-34", scopes: ["source.toml", "variable.other.key.toml"]
+    expect(tokens[1]).toEqual value: " ", scopes: ["source.toml"]
+    expect(tokens[2]).toEqual value: "=", scopes: ["source.toml", "keyword.operator.assignment.toml"]
+
+    {tokens} = grammar.tokenizeLine("ʎǝʞ =")
+    expect(tokens[0]).toEqual value: "ʎǝʞ =", scopes: ["source.toml"]
+
+    {tokens} = grammar.tokenizeLine("  =")
+    expect(tokens[0]).toEqual value: "  =", scopes: ["source.toml"]
+
+  it "tokenizes quoted keys", ->
+    {tokens} = grammar.tokenizeLine("'key' =")
+    expect(tokens[0]).toEqual value: "'", scopes: ["source.toml", "string.quoted.single.toml", "punctuation.definition.string.begin.toml"]
+    expect(tokens[1]).toEqual value: "key", scopes: ["source.toml", "string.quoted.single.toml", "variable.other.key.toml"]
+    expect(tokens[2]).toEqual value: "'", scopes: ["source.toml", "string.quoted.single.toml", "punctuation.definition.string.end.toml"]
+    expect(tokens[3]).toEqual value: " ", scopes: ["source.toml"]
+    expect(tokens[4]).toEqual value: "=", scopes: ["source.toml", "keyword.operator.assignment.toml"]
+
+    {tokens} = grammar.tokenizeLine("'ʎǝʞ' =")
+    expect(tokens[0]).toEqual value: "'", scopes: ["source.toml", "string.quoted.single.toml", "punctuation.definition.string.begin.toml"]
+    expect(tokens[1]).toEqual value: "ʎǝʞ", scopes: ["source.toml", "string.quoted.single.toml", "variable.other.key.toml"]
+    expect(tokens[2]).toEqual value: "'", scopes: ["source.toml", "string.quoted.single.toml", "punctuation.definition.string.end.toml"]
+    expect(tokens[3]).toEqual value: " ", scopes: ["source.toml"]
+    expect(tokens[4]).toEqual value: "=", scopes: ["source.toml", "keyword.operator.assignment.toml"]
+
+    {tokens} = grammar.tokenizeLine("'key with spaces' =")
+    expect(tokens[0]).toEqual value: "'", scopes: ["source.toml", "string.quoted.single.toml", "punctuation.definition.string.begin.toml"]
+    expect(tokens[1]).toEqual value: "key with spaces", scopes: ["source.toml", "string.quoted.single.toml", "variable.other.key.toml"]
+    expect(tokens[2]).toEqual value: "'", scopes: ["source.toml", "string.quoted.single.toml", "punctuation.definition.string.end.toml"]
+    expect(tokens[3]).toEqual value: " ", scopes: ["source.toml"]
+    expect(tokens[4]).toEqual value: "=", scopes: ["source.toml", "keyword.operator.assignment.toml"]
+
+    {tokens} = grammar.tokenizeLine("'' =")
+    expect(tokens[0]).toEqual value: "'", scopes: ["source.toml", "string.quoted.single.toml", "punctuation.definition.string.begin.toml"]
+    expect(tokens[1]).toEqual value: "'", scopes: ["source.toml", "string.quoted.single.toml", "punctuation.definition.string.end.toml"]
+    expect(tokens[2]).toEqual value: " ", scopes: ["source.toml"]
+    expect(tokens[3]).toEqual value: "=", scopes: ["source.toml", "keyword.operator.assignment.toml"]
+
+    {tokens} = grammar.tokenizeLine('"key" =')
+    expect(tokens[0]).toEqual value: '"', scopes: ["source.toml", "string.quoted.double.toml", "punctuation.definition.string.begin.toml"]
+    expect(tokens[1]).toEqual value: "key", scopes: ["source.toml", "string.quoted.double.toml", "variable.other.key.toml"]
+    expect(tokens[2]).toEqual value: '"', scopes: ["source.toml", "string.quoted.double.toml", "punctuation.definition.string.end.toml"]
+    expect(tokens[3]).toEqual value: " ", scopes: ["source.toml"]
+    expect(tokens[4]).toEqual value: "=", scopes: ["source.toml", "keyword.operator.assignment.toml"]
+
+    {tokens} = grammar.tokenizeLine('"ʎǝʞ" =')
+    expect(tokens[0]).toEqual value: '"', scopes: ["source.toml", "string.quoted.double.toml", "punctuation.definition.string.begin.toml"]
+    expect(tokens[1]).toEqual value: "ʎǝʞ", scopes: ["source.toml", "string.quoted.double.toml", "variable.other.key.toml"]
+    expect(tokens[2]).toEqual value: '"', scopes: ["source.toml", "string.quoted.double.toml", "punctuation.definition.string.end.toml"]
+    expect(tokens[3]).toEqual value: " ", scopes: ["source.toml"]
+    expect(tokens[4]).toEqual value: "=", scopes: ["source.toml", "keyword.operator.assignment.toml"]
+
+    {tokens} = grammar.tokenizeLine('"key with spaces" =')
+    expect(tokens[0]).toEqual value: '"', scopes: ["source.toml", "string.quoted.double.toml", "punctuation.definition.string.begin.toml"]
+    expect(tokens[1]).toEqual value: "key with spaces", scopes: ["source.toml", "string.quoted.double.toml", "variable.other.key.toml"]
+    expect(tokens[2]).toEqual value: '"', scopes: ["source.toml", "string.quoted.double.toml", "punctuation.definition.string.end.toml"]
+    expect(tokens[3]).toEqual value: " ", scopes: ["source.toml"]
+    expect(tokens[4]).toEqual value: "=", scopes: ["source.toml", "keyword.operator.assignment.toml"]
+
+    {tokens} = grammar.tokenizeLine('"" =')
+    expect(tokens[0]).toEqual value: '"', scopes: ["source.toml", "string.quoted.double.toml", "punctuation.definition.string.begin.toml"]
+    expect(tokens[1]).toEqual value: '"', scopes: ["source.toml", "string.quoted.double.toml", "punctuation.definition.string.end.toml"]
+    expect(tokens[2]).toEqual value: " ", scopes: ["source.toml"]
+    expect(tokens[3]).toEqual value: "=", scopes: ["source.toml", "keyword.operator.assignment.toml"]


### PR DESCRIPTION
Fixes #11
Fixes #8 for real this time

The problem was that the key matching was starting *at the start of the line* and matching whitespace *all the way* until it hit a non-whitespace character.  So no matter what priority the other rules were given, the key matching would almost always prevail anyway.  They now just look for a simpler `word =` pattern.

Also added support for quoted strings, which allow for a wider variety of characters than non-quoted ones.