### PR TITLE
Add firstLineMatch support for Vim/Emacs modelines

### DIFF
--- a/grammars/toml.cson
+++ b/grammars/toml.cson
@@ -1,6 +1,17 @@
 'name': 'TOML'
 'scopeName': 'source.toml'
 'fileTypes': ['toml']
+'firstLineMatch': '''(?xi)
+  # Emacs modeline
+  -\\*-(?:\\s*(?=[^:;\\s]+\\s*-\\*-)|(?:.*?[;\\s]|(?<=-\\*-))mode\\s*:\\s*)
+    toml
+  (?=[\\s;]|(?<![-*])-\\*-).*?-\\*-
+  |
+  # Vim modeline
+  (?:(?:\\s|^)vi(?:m[<=>]?\\d+|m)?|\\sex)(?=:(?=\\s*set?\\s[^\\n:]+:)|:(?!\\s*set?\\s))(?:(?:\\s|\\s*:\\s*)\\w*(?:\\s*=(?:[^\\n\\\\\\s]|\\\\.)*)?)*[\\s:](?:filetype|ft|syntax)\\s*=
+    toml
+  (?=\\s|:|$)
+'''
 'patterns': [
   {
     'match': '(#).*$'


### PR DESCRIPTION
Wasn't sure whether or not to add this, as neither Emacs or Vim provide out-of-the-box support for TOML the way Atom does. However, both editors have community packages that add TOML support:

* **Emacs:** https://github.com/dryman/toml-mode.el
* **Vim:** https://github.com/cespare/vim-toml

Both are listed in the official TOML repository's [list of supporting editors](https://github.com/toml-lang/toml#editor-support).