### PR TITLE
Relax quoted key restrictions

### DIFF
--- a/grammars/toml.cson
+++ b/grammars/toml.cson
@@ -29,16 +29,22 @@
       '2': 'name': 'keyword.operator.assignment.toml'
   }
   {
-    'match': '((")([\\w\\s-]*)("))\\s*(=)' # We use \\w here because quoted keys allow for a much wider variety.
+    'match': '((")([^"]*)("))\\s*(=)'
     'captures':
       '1': 'name': 'string.quoted.double.toml'
       '2': 'name': 'punctuation.definition.string.begin.toml'
-      '3': 'name': 'variable.other.key.toml'
+      '3':
+        'name': 'variable.other.key.toml'
+        'patterns': [
+          {
+            'include': '#string-escapes'
+          }
+        ]
       '4': 'name': 'punctuation.definition.string.end.toml'
       '5': 'name': 'keyword.operator.assignment.toml'
   }
   {
-    'match': "((')([\\w\\s-]*)('))\\s*(=)" # We use \\w here because quoted keys allow for a much wider variety.
+    'match': "((')([^']*)('))\\s*(=)"
     'captures':
       '1': 'name': 'string.quoted.single.toml'
       '2': 'name': 'punctuation.definition.string.begin.toml'
@@ -55,8 +61,13 @@
       '0': 'name': 'punctuation.definition.string.end.toml'
     'name': 'string.quoted.double.block.toml'
     'patterns': [
-      'match': '\\\\[btnfr"\\\\]|\\\\u[A-Fa-f0-9]{4}|\\\\U[A-Fa-f0-9]{8}|\\\\$'
-      'name': 'constant.character.escape.toml'
+      {
+        'include': '#string-escapes'
+      }
+      {
+        'match': '\\\\$'
+        'name': 'constant.character.escape.toml'
+      }
     ]
   }
   {
@@ -77,8 +88,9 @@
       '0': 'name': 'punctuation.definition.string.end.toml'
     'name': 'string.quoted.double.toml'
     'patterns': [
-      'match': '\\\\[btnfr"\\\\]|\\\\u[A-Fa-f0-9]{4}|\\\\U[A-Fa-f0-9]{8}'
-      'name': 'constant.character.escape.toml'
+      {
+        'include': '#string-escapes'
+      }
     ]
   }
   {
@@ -111,3 +123,7 @@
     'name': 'constant.numeric.toml'
   }
 ]
+'repository':
+  'string-escapes':
+    'match': '\\\\[btnfr"\\\\]|\\\\u[A-Fa-f0-9]{4}|\\\\U[A-Fa-f0-9]{8}'
+    'name': 'constant.character.escape.toml'

--- a/grammars/toml.cson
+++ b/grammars/toml.cson
@@ -29,7 +29,7 @@
       '2': 'name': 'keyword.operator.assignment.toml'
   }
   {
-    'match': '((")([^"]*)("))\\s*(=)'
+    'match': '((")(.*)("))\\s*(=)' # This one is .* because " can be escaped
     'captures':
       '1': 'name': 'string.quoted.double.toml'
       '2': 'name': 'punctuation.definition.string.begin.toml'

--- a/spec/toml-spec.coffee
+++ b/spec/toml-spec.coffee
@@ -163,6 +163,13 @@ describe "TOML grammar", ->
     expect(tokens[3]).toEqual value: " ", scopes: ["source.toml"]
     expect(tokens[4]).toEqual value: "=", scopes: ["source.toml", "keyword.operator.assignment.toml"]
 
+    {tokens} = grammar.tokenizeLine("'key with colons:' =")
+    expect(tokens[0]).toEqual value: "'", scopes: ["source.toml", "string.quoted.single.toml", "punctuation.definition.string.begin.toml"]
+    expect(tokens[1]).toEqual value: "key with colons:", scopes: ["source.toml", "string.quoted.single.toml", "variable.other.key.toml"]
+    expect(tokens[2]).toEqual value: "'", scopes: ["source.toml", "string.quoted.single.toml", "punctuation.definition.string.end.toml"]
+    expect(tokens[3]).toEqual value: " ", scopes: ["source.toml"]
+    expect(tokens[4]).toEqual value: "=", scopes: ["source.toml", "keyword.operator.assignment.toml"]
+
     {tokens} = grammar.tokenizeLine("'' =")
     expect(tokens[0]).toEqual value: "'", scopes: ["source.toml", "string.quoted.single.toml", "punctuation.definition.string.begin.toml"]
     expect(tokens[1]).toEqual value: "'", scopes: ["source.toml", "string.quoted.single.toml", "punctuation.definition.string.end.toml"]
@@ -189,6 +196,22 @@ describe "TOML grammar", ->
     expect(tokens[2]).toEqual value: '"', scopes: ["source.toml", "string.quoted.double.toml", "punctuation.definition.string.end.toml"]
     expect(tokens[3]).toEqual value: " ", scopes: ["source.toml"]
     expect(tokens[4]).toEqual value: "=", scopes: ["source.toml", "keyword.operator.assignment.toml"]
+
+    {tokens} = grammar.tokenizeLine('"key with colons:" =')
+    expect(tokens[0]).toEqual value: '"', scopes: ["source.toml", "string.quoted.double.toml", "punctuation.definition.string.begin.toml"]
+    expect(tokens[1]).toEqual value: "key with colons:", scopes: ["source.toml", "string.quoted.double.toml", "variable.other.key.toml"]
+    expect(tokens[2]).toEqual value: '"', scopes: ["source.toml", "string.quoted.double.toml", "punctuation.definition.string.end.toml"]
+    expect(tokens[3]).toEqual value: " ", scopes: ["source.toml"]
+    expect(tokens[4]).toEqual value: "=", scopes: ["source.toml", "keyword.operator.assignment.toml"]
+
+    {tokens} = grammar.tokenizeLine('"key wi\\th escapes" =')
+    expect(tokens[0]).toEqual value: '"', scopes: ["source.toml", "string.quoted.double.toml", "punctuation.definition.string.begin.toml"]
+    expect(tokens[1]).toEqual value: "key wi", scopes: ["source.toml", "string.quoted.double.toml", "variable.other.key.toml"]
+    expect(tokens[2]).toEqual value: "\\t", scopes: ["source.toml", "string.quoted.double.toml", "variable.other.key.toml", "constant.character.escape.toml"]
+    expect(tokens[3]).toEqual value: "h escapes", scopes: ["source.toml", "string.quoted.double.toml", "variable.other.key.toml"]
+    expect(tokens[4]).toEqual value: '"', scopes: ["source.toml", "string.quoted.double.toml", "punctuation.definition.string.end.toml"]
+    expect(tokens[5]).toEqual value: " ", scopes: ["source.toml"]
+    expect(tokens[6]).toEqual value: "=", scopes: ["source.toml", "keyword.operator.assignment.toml"]
 
     {tokens} = grammar.tokenizeLine('"" =')
     expect(tokens[0]).toEqual value: '"', scopes: ["source.toml", "string.quoted.double.toml", "punctuation.definition.string.begin.toml"]

--- a/spec/toml-spec.coffee
+++ b/spec/toml-spec.coffee
@@ -213,6 +213,15 @@ describe "TOML grammar", ->
     expect(tokens[5]).toEqual value: " ", scopes: ["source.toml"]
     expect(tokens[6]).toEqual value: "=", scopes: ["source.toml", "keyword.operator.assignment.toml"]
 
+    {tokens} = grammar.tokenizeLine('"key with \\" quote" =')
+    expect(tokens[0]).toEqual value: '"', scopes: ["source.toml", "string.quoted.double.toml", "punctuation.definition.string.begin.toml"]
+    expect(tokens[1]).toEqual value: "key with ", scopes: ["source.toml", "string.quoted.double.toml", "variable.other.key.toml"]
+    expect(tokens[2]).toEqual value: '\\"', scopes: ["source.toml", "string.quoted.double.toml", "variable.other.key.toml", "constant.character.escape.toml"]
+    expect(tokens[3]).toEqual value: " quote", scopes: ["source.toml", "string.quoted.double.toml", "variable.other.key.toml"]
+    expect(tokens[4]).toEqual value: '"', scopes: ["source.toml", "string.quoted.double.toml", "punctuation.definition.string.end.toml"]
+    expect(tokens[5]).toEqual value: " ", scopes: ["source.toml"]
+    expect(tokens[6]).toEqual value: "=", scopes: ["source.toml", "keyword.operator.assignment.toml"]
+
     {tokens} = grammar.tokenizeLine('"" =')
     expect(tokens[0]).toEqual value: '"', scopes: ["source.toml", "string.quoted.double.toml", "punctuation.definition.string.begin.toml"]
     expect(tokens[1]).toEqual value: '"', scopes: ["source.toml", "string.quoted.double.toml", "punctuation.definition.string.end.toml"]


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

For some unknown reason that I can't remember I restricted quoted keys to word characters, spaces, and dashes only, while the spec states that it can contain anything that a regular string can.  So this PR rectifies that.

### Alternate Designs

None.

### Benefits

Improved quoted key matching.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #16