### PR TITLE
Allow for more than one key/value pair per line

### DIFF
--- a/grammars/toml.cson
+++ b/grammars/toml.cson
@@ -3,10 +3,7 @@
 'fileTypes': ['toml']
 'patterns': [
   {
-    'match': '(#).*$'
-    'name': 'comment.line.number-sign.toml'
-    'captures':
-      '1': 'name': 'punctuation.definition.comment.toml'
+    'include': '#comment'
   }
   {
     'match': '(?:^\\s*)((\\[\\[)[^\\]]+(\\]\\]))'
@@ -23,16 +20,26 @@
       '3': 'name': 'punctuation.definition.table.end.toml'
   }
   {
-    'match': '([A-Za-z0-9_-]+)\\s*(=)' # IMPORTANT: Do not replace with [\\w-].  \\w includes more than just a-z.
-    'captures':
-      '1': 'name': 'variable.other.key.toml'
-      '2': 'name': 'keyword.operator.assignment.toml'
+    'begin': '([A-Za-z0-9_-]+)\\s*(=)\\s*' # IMPORTANT: Do not replace with [\\w-]. \\w includes more than just a-z.
+    'beginCaptures':
+      '1':
+        'name': 'variable.other.key.toml'
+      '2':
+        'name': 'keyword.operator.assignment.toml'
+    'end': '(?!\\G)'
+    'patterns': [
+      {
+        'include': '#values'
+      }
+    ]
   }
   {
-    'match': '((")(.*)("))\\s*(=)' # This one is .* because " can be escaped
-    'captures':
-      '1': 'name': 'string.quoted.double.toml'
-      '2': 'name': 'punctuation.definition.string.begin.toml'
+    'begin': '((")(.*?)("))\\s*(=)\\s*' # This one is .* because " can be escaped
+    'beginCaptures':
+      '1':
+        'name': 'string.quoted.double.toml'
+      '2':
+        'name': 'punctuation.definition.string.begin.toml'
       '3':
         'name': 'variable.other.key.toml'
         'patterns': [
@@ -40,90 +47,162 @@
             'include': '#string-escapes'
           }
         ]
-      '4': 'name': 'punctuation.definition.string.end.toml'
-      '5': 'name': 'keyword.operator.assignment.toml'
-  }
-  {
-    'match': "((')([^']*)('))\\s*(=)"
-    'captures':
-      '1': 'name': 'string.quoted.single.toml'
-      '2': 'name': 'punctuation.definition.string.begin.toml'
-      '3': 'name': 'variable.other.key.toml'
-      '4': 'name': 'punctuation.definition.string.end.toml'
-      '5': 'name': 'keyword.operator.assignment.toml'
-  }
-  {
-    'begin': '"""'
-    'beginCaptures':
-      '0': 'name': 'punctuation.definition.string.begin.toml'
-    'end': '"""'
-    'endCaptures':
-      '0': 'name': 'punctuation.definition.string.end.toml'
-    'name': 'string.quoted.double.block.toml'
+      '4':
+        'name': 'punctuation.definition.string.end.toml'
+      '5':
+        'name': 'keyword.operator.assignment.toml'
+    'end': '(?!\\G)'
     'patterns': [
       {
-        'include': '#string-escapes'
-      }
-      {
-        'match': '\\\\$'
-        'name': 'constant.character.escape.toml'
+        'include': '#values'
       }
     ]
   }
   {
-    'begin': "'''"
+    'begin': "((')([^']*)('))\\s*(=)\\s*"
     'beginCaptures':
-      '0': 'name': 'punctuation.definition.string.begin.toml'
-    'end': "'''"
-    'endCaptures':
-      '0': 'name': 'punctuation.definition.string.end.toml'
-    'name': 'string.quoted.single.block.toml'
-  }
-  {
-    'begin': '"'
-    'beginCaptures':
-      '0': 'name': 'punctuation.definition.string.begin.toml'
-    'end': '"'
-    'endCaptures':
-      '0': 'name': 'punctuation.definition.string.end.toml'
-    'name': 'string.quoted.double.toml'
+      '1':
+        'name': 'string.quoted.single.toml'
+      '2':
+        'name': 'punctuation.definition.string.begin.toml'
+      '3':
+        'name': 'variable.other.key.toml'
+      '4':
+        'name': 'punctuation.definition.string.end.toml'
+      '5':
+        'name': 'keyword.operator.assignment.toml'
+    'end': '(?!\\G)'
     'patterns': [
       {
-        'include': '#string-escapes'
+        'include': '#values'
       }
     ]
-  }
-  {
-    'begin': "'"
-    'beginCaptures':
-      '0': 'name': 'punctuation.definition.string.begin.toml'
-    'end': "'"
-    'endCaptures':
-      '0': 'name': 'punctuation.definition.string.end.toml'
-    'name': 'string.quoted.single.toml'
-  }
-  {
-    'match': 'true'
-    'name': 'constant.language.boolean.true.toml'
-  }
-  {
-    'match': 'false'
-    'name': 'constant.language.boolean.false.toml'
-  }
-  {
-    'match': '\\d{4}-\\d{2}-\\d{2}(?:(T)\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:(Z)|([+-])\\d{2}:\\d{2})?)?'
-    'name': 'constant.numeric.date.toml'
-    'captures':
-      '1': 'name': 'keyword.other.time.toml'
-      '2': 'name': 'keyword.other.offset.toml'
-      '3': 'name': 'keyword.other.offset.toml'
-  }
-  {
-    'match': '[+-]?(0|[1-9]\\d*)(_\\d+)*((\\.\\d+)(_\\d+)*)?([eE][+-]?\\d+(_\\d+)*)?'
-    'name': 'constant.numeric.toml'
   }
 ]
 'repository':
+  'comment':
+    'patterns': [
+      {
+        'match': '(#).*$'
+        'name': 'comment.line.number-sign.toml'
+        'captures':
+          '1': 'name': 'punctuation.definition.comment.toml'
+      }
+    ]
   'string-escapes':
     'match': '\\\\[btnfr"\\\\]|\\\\u[A-Fa-f0-9]{4}|\\\\U[A-Fa-f0-9]{8}'
     'name': 'constant.character.escape.toml'
+  'values':
+    'patterns': [
+      {
+        'begin': '\\['
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.array.begin.toml'
+        'end': '\\]'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.array.end.toml'
+        'patterns': [
+          {
+            'include': '#comment'
+          }
+          {
+            'match': ','
+            'name': 'punctuation.definition.separator.comma.toml'
+          }
+          {
+            'include': '#values'
+          }
+        ]
+      }
+      {
+        'begin': '{'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.table.inline.begin.toml'
+        'end': '}'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.table.inline.end.toml'
+        'patterns': [
+          {
+            'match': ','
+            'name': 'punctuation.definition.separator.comma.toml'
+          }
+          {
+            'include': '$self'
+          }
+        ]
+      }
+      {
+        'begin': '"""'
+        'beginCaptures':
+          '0': 'name': 'punctuation.definition.string.begin.toml'
+        'end': '"""'
+        'endCaptures':
+          '0': 'name': 'punctuation.definition.string.end.toml'
+        'name': 'string.quoted.double.block.toml'
+        'patterns': [
+          {
+            'include': '#string-escapes'
+          }
+          {
+            'match': '\\\\$'
+            'name': 'constant.character.escape.toml'
+          }
+        ]
+      }
+      {
+        'begin': "'''"
+        'beginCaptures':
+          '0': 'name': 'punctuation.definition.string.begin.toml'
+        'end': "'''"
+        'endCaptures':
+          '0': 'name': 'punctuation.definition.string.end.toml'
+        'name': 'string.quoted.single.block.toml'
+      }
+      {
+        'begin': '"'
+        'beginCaptures':
+          '0': 'name': 'punctuation.definition.string.begin.toml'
+        'end': '"'
+        'endCaptures':
+          '0': 'name': 'punctuation.definition.string.end.toml'
+        'name': 'string.quoted.double.toml'
+        'patterns': [
+          {
+            'include': '#string-escapes'
+          }
+        ]
+      }
+      {
+        'begin': "'"
+        'beginCaptures':
+          '0': 'name': 'punctuation.definition.string.begin.toml'
+        'end': "'"
+        'endCaptures':
+          '0': 'name': 'punctuation.definition.string.end.toml'
+        'name': 'string.quoted.single.toml'
+      }
+      {
+        'match': 'true'
+        'name': 'constant.language.boolean.true.toml'
+      }
+      {
+        'match': 'false'
+        'name': 'constant.language.boolean.false.toml'
+      }
+      {
+        'match': '\\d{4}-\\d{2}-\\d{2}(?:(T)\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:(Z)|([+-])\\d{2}:\\d{2})?)?'
+        'name': 'constant.numeric.date.toml'
+        'captures':
+          '1': 'name': 'keyword.other.time.toml'
+          '2': 'name': 'keyword.other.offset.toml'
+          '3': 'name': 'keyword.other.offset.toml'
+      }
+      {
+        'match': '[+-]?(0|[1-9]\\d*)(_\\d+)*((\\.\\d+)(_\\d+)*)?([eE][+-]?\\d+(_\\d+)*)?'
+        'name': 'constant.numeric.toml'
+      }
+    ]

--- a/spec/toml-spec.coffee
+++ b/spec/toml-spec.coffee
@@ -30,82 +30,84 @@ describe "TOML grammar", ->
     expect(tokens[2]).toEqual value: "Whitespace = tricky", scopes: ["source.toml", "comment.line.number-sign.toml"]
 
   it "tokenizes strings", ->
-    {tokens} = grammar.tokenizeLine('"I am a string"')
-    expect(tokens[0]).toEqual value: '"', scopes: ["source.toml", "string.quoted.double.toml", "punctuation.definition.string.begin.toml"]
-    expect(tokens[1]).toEqual value: 'I am a string', scopes: ["source.toml", "string.quoted.double.toml"]
-    expect(tokens[2]).toEqual value: '"', scopes: ["source.toml", "string.quoted.double.toml", "punctuation.definition.string.end.toml"]
+    {tokens} = grammar.tokenizeLine('foo = "I am a string"')
+    expect(tokens[4]).toEqual value: '"', scopes: ["source.toml", "string.quoted.double.toml", "punctuation.definition.string.begin.toml"]
+    expect(tokens[5]).toEqual value: 'I am a string', scopes: ["source.toml", "string.quoted.double.toml"]
+    expect(tokens[6]).toEqual value: '"', scopes: ["source.toml", "string.quoted.double.toml", "punctuation.definition.string.end.toml"]
 
-    {tokens} = grammar.tokenizeLine('"I\'m \\n escaped"')
-    expect(tokens[0]).toEqual value: '"', scopes: ["source.toml", "string.quoted.double.toml", "punctuation.definition.string.begin.toml"]
-    expect(tokens[1]).toEqual value: "I'm ", scopes: ["source.toml", "string.quoted.double.toml"]
-    expect(tokens[2]).toEqual value: "\\n", scopes: ["source.toml", "string.quoted.double.toml", "constant.character.escape.toml"]
-    expect(tokens[3]).toEqual value: " escaped", scopes: ["source.toml", "string.quoted.double.toml"]
-    expect(tokens[4]).toEqual value: '"', scopes: ["source.toml", "string.quoted.double.toml", "punctuation.definition.string.end.toml"]
+    {tokens} = grammar.tokenizeLine('foo = "I\'m \\n escaped"')
+    expect(tokens[4]).toEqual value: '"', scopes: ["source.toml", "string.quoted.double.toml", "punctuation.definition.string.begin.toml"]
+    expect(tokens[5]).toEqual value: "I'm ", scopes: ["source.toml", "string.quoted.double.toml"]
+    expect(tokens[6]).toEqual value: "\\n", scopes: ["source.toml", "string.quoted.double.toml", "constant.character.escape.toml"]
+    expect(tokens[7]).toEqual value: " escaped", scopes: ["source.toml", "string.quoted.double.toml"]
+    expect(tokens[8]).toEqual value: '"', scopes: ["source.toml", "string.quoted.double.toml", "punctuation.definition.string.end.toml"]
 
-    {tokens} = grammar.tokenizeLine("'I am not \\n escaped'")
-    expect(tokens[0]).toEqual value: "'", scopes: ["source.toml", "string.quoted.single.toml", "punctuation.definition.string.begin.toml"]
-    expect(tokens[1]).toEqual value: 'I am not \\n escaped', scopes: ["source.toml", "string.quoted.single.toml"]
-    expect(tokens[2]).toEqual value: "'", scopes: ["source.toml", "string.quoted.single.toml", "punctuation.definition.string.end.toml"]
+    {tokens} = grammar.tokenizeLine("foo = 'I am not \\n escaped'")
+    expect(tokens[4]).toEqual value: "'", scopes: ["source.toml", "string.quoted.single.toml", "punctuation.definition.string.begin.toml"]
+    expect(tokens[5]).toEqual value: 'I am not \\n escaped', scopes: ["source.toml", "string.quoted.single.toml"]
+    expect(tokens[6]).toEqual value: "'", scopes: ["source.toml", "string.quoted.single.toml", "punctuation.definition.string.end.toml"]
 
-    {tokens} = grammar.tokenizeLine('"Equal sign ahead = no problem"')
-    expect(tokens[0]).toEqual value: '"', scopes: ["source.toml", "string.quoted.double.toml", "punctuation.definition.string.begin.toml"]
-    expect(tokens[1]).toEqual value: 'Equal sign ahead = no problem', scopes: ["source.toml", "string.quoted.double.toml"]
-    expect(tokens[2]).toEqual value: '"', scopes: ["source.toml", "string.quoted.double.toml", "punctuation.definition.string.end.toml"]
+    {tokens} = grammar.tokenizeLine('foo = "Equal sign ahead = no problem"')
+    expect(tokens[4]).toEqual value: '"', scopes: ["source.toml", "string.quoted.double.toml", "punctuation.definition.string.begin.toml"]
+    expect(tokens[5]).toEqual value: 'Equal sign ahead = no problem', scopes: ["source.toml", "string.quoted.double.toml"]
+    expect(tokens[6]).toEqual value: '"', scopes: ["source.toml", "string.quoted.double.toml", "punctuation.definition.string.end.toml"]
+
+  it "does not tokenize equal signs within strings", ->
+    {tokens} = grammar.tokenizeLine('pywinusb = { version = "*", os_name = "==\'nt\'", index="pypi"}')
+    expect(tokens[20]).toEqual value: "=='nt'", scopes: ["source.toml", "string.quoted.double.toml"]
 
   it "tokenizes multiline strings", ->
-    lines = grammar.tokenizeLines '''
-      """
+    lines = grammar.tokenizeLines '''foo = """
       I am a\\
       string
       """
     '''
-    expect(lines[0][0]).toEqual value: '"""', scopes: ["source.toml", "string.quoted.double.block.toml", "punctuation.definition.string.begin.toml"]
+    expect(lines[0][4]).toEqual value: '"""', scopes: ["source.toml", "string.quoted.double.block.toml", "punctuation.definition.string.begin.toml"]
     expect(lines[1][0]).toEqual value: 'I am a', scopes: ["source.toml", "string.quoted.double.block.toml"]
     expect(lines[1][1]).toEqual value: '\\', scopes: ["source.toml", "string.quoted.double.block.toml", "constant.character.escape.toml"]
     expect(lines[2][0]).toEqual value: 'string', scopes: ["source.toml", "string.quoted.double.block.toml"]
     expect(lines[3][0]).toEqual value: '"""', scopes: ["source.toml", "string.quoted.double.block.toml", "punctuation.definition.string.end.toml"]
 
-    lines = grammar.tokenizeLines """
-      '''
+    lines = grammar.tokenizeLines """foo = '''
       I am a\\
       string
       '''
     """
-    expect(lines[0][0]).toEqual value: "'''", scopes: ["source.toml", "string.quoted.single.block.toml", "punctuation.definition.string.begin.toml"]
+    expect(lines[0][4]).toEqual value: "'''", scopes: ["source.toml", "string.quoted.single.block.toml", "punctuation.definition.string.begin.toml"]
     expect(lines[1][0]).toEqual value: 'I am a\\', scopes: ["source.toml", "string.quoted.single.block.toml"]
     expect(lines[2][0]).toEqual value: 'string', scopes: ["source.toml", "string.quoted.single.block.toml"]
     expect(lines[3][0]).toEqual value: "'''", scopes: ["source.toml", "string.quoted.single.block.toml", "punctuation.definition.string.end.toml"]
 
   it "tokenizes booleans", ->
-    {tokens} = grammar.tokenizeLine("true")
-    expect(tokens[0]).toEqual value: "true", scopes: ["source.toml", "constant.language.boolean.true.toml"]
+    {tokens} = grammar.tokenizeLine("foo = true")
+    expect(tokens[4]).toEqual value: "true", scopes: ["source.toml", "constant.language.boolean.true.toml"]
 
-    {tokens} = grammar.tokenizeLine("false")
-    expect(tokens[0]).toEqual value: "false", scopes: ["source.toml", "constant.language.boolean.false.toml"]
+    {tokens} = grammar.tokenizeLine("foo = false")
+    expect(tokens[4]).toEqual value: "false", scopes: ["source.toml", "constant.language.boolean.false.toml"]
 
   it "tokenizes integers", ->
     for int in ["+99", "42", "0", "-17", "1_000", "1_2_3_4_5"]
-      {tokens} = grammar.tokenizeLine(int)
-      expect(tokens[0]).toEqual value: int, scopes: ["source.toml", "constant.numeric.toml"]
+      {tokens} = grammar.tokenizeLine("foo = #{int}")
+      expect(tokens[4]).toEqual value: int, scopes: ["source.toml", "constant.numeric.toml"]
 
   it "tokenizes floats", ->
     for float in ["+1.0", "3.1415", "-0.01", "5e+22", "1e6", "-2E-2", "6.626e-34", "6.626e-34", "9_224_617.445_991_228_313", "1e1_000"]
-      {tokens} = grammar.tokenizeLine(float)
-      expect(tokens[0]).toEqual value: float, scopes: ["source.toml", "constant.numeric.toml"]
+      {tokens} = grammar.tokenizeLine("foo = #{float}")
+      expect(tokens[4]).toEqual value: float, scopes: ["source.toml", "constant.numeric.toml"]
 
   it "tokenizes dates", ->
-    {tokens} = grammar.tokenizeLine("1979-05-27T07:32:00Z")
-    expect(tokens[0]).toEqual value: "1979-05-27", scopes: ["source.toml", "constant.numeric.date.toml"]
-    expect(tokens[1]).toEqual value: "T", scopes: ["source.toml", "constant.numeric.date.toml", "keyword.other.time.toml"]
-    expect(tokens[2]).toEqual value: "07:32:00", scopes: ["source.toml", "constant.numeric.date.toml"]
-    expect(tokens[3]).toEqual value: "Z", scopes: ["source.toml", "constant.numeric.date.toml", "keyword.other.offset.toml"]
+    {tokens} = grammar.tokenizeLine("foo = 1979-05-27T07:32:00Z")
+    expect(tokens[4]).toEqual value: "1979-05-27", scopes: ["source.toml", "constant.numeric.date.toml"]
+    expect(tokens[5]).toEqual value: "T", scopes: ["source.toml", "constant.numeric.date.toml", "keyword.other.time.toml"]
+    expect(tokens[6]).toEqual value: "07:32:00", scopes: ["source.toml", "constant.numeric.date.toml"]
+    expect(tokens[7]).toEqual value: "Z", scopes: ["source.toml", "constant.numeric.date.toml", "keyword.other.offset.toml"]
 
-    {tokens} = grammar.tokenizeLine("1979-05-27T00:32:00.999999-07:00")
-    expect(tokens[0]).toEqual value: "1979-05-27", scopes: ["source.toml", "constant.numeric.date.toml"]
-    expect(tokens[1]).toEqual value: "T", scopes: ["source.toml", "constant.numeric.date.toml", "keyword.other.time.toml"]
-    expect(tokens[2]).toEqual value: "00:32:00.999999", scopes: ["source.toml", "constant.numeric.date.toml"]
-    expect(tokens[3]).toEqual value: "-", scopes: ["source.toml", "constant.numeric.date.toml", "keyword.other.offset.toml"]
-    expect(tokens[4]).toEqual value: "07:00", scopes: ["source.toml", "constant.numeric.date.toml"]
+    {tokens} = grammar.tokenizeLine("foo = 1979-05-27T00:32:00.999999-07:00")
+    expect(tokens[4]).toEqual value: "1979-05-27", scopes: ["source.toml", "constant.numeric.date.toml"]
+    expect(tokens[5]).toEqual value: "T", scopes: ["source.toml", "constant.numeric.date.toml", "keyword.other.time.toml"]
+    expect(tokens[6]).toEqual value: "00:32:00.999999", scopes: ["source.toml", "constant.numeric.date.toml"]
+    expect(tokens[7]).toEqual value: "-", scopes: ["source.toml", "constant.numeric.date.toml", "keyword.other.offset.toml"]
+    expect(tokens[8]).toEqual value: "07:00", scopes: ["source.toml", "constant.numeric.date.toml"]
 
   it "tokenizes tables", ->
     {tokens} = grammar.tokenizeLine("[table]")


### PR DESCRIPTION
### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

This PR fixes an error in the grammar which can cause strings to be tokenized incorrectly, leading to equal signs (within strings) to be tokenized and to the rest of file being mis-highlighted. I've tweaked the grammar so this can't happen.

Consider the following Pipfile, which is taken directly from the [Pipfile README](https://github.com/pypa/pipfile#readme). Before this fix was applied, the highlighting was screwy when `"(.*?)"\s*(=)` is matched. Note the red equal sign in the middle of what should be a gold string, and note that the rest of the file is mis-highlighted:

<img width="731" alt="1-incorrect" src="https://user-images.githubusercontent.com/872474/53387059-e803e800-3939-11e9-9019-8c9d082dd8d1.png">

With my fix applied, highlighting is now looking more consistent. I have added an additional test to confirm this, and all existing tests are still passing as well. :)

<img width="723" alt="2-correct" src="https://user-images.githubusercontent.com/872474/53387092-184b8680-393a-11e9-8ab0-86cb56c77389.png">

### Alternate Designs

N/A

### Benefits

Better syntax highlighting for more sophisticated TOML files.

### Possible Drawbacks

It's possible this change could introduce a hidden regression in the highlighting of TOML files, though I have not seen such in my testing, and the rest of the Pipfile I referenced above appears just fine.

### Applicable Issues

N/A
