### PR TITLE
TOML 0.5 date-time compatibility

### DIFF
--- a/grammars/toml.cson
+++ b/grammars/toml.cson
@@ -194,7 +194,18 @@
         'name': 'constant.language.boolean.false.toml'
       }
       {
-        'match': '\\d{4}-\\d{2}-\\d{2}(?:(T)\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:(Z)|([+-])\\d{2}:\\d{2})?)?'
+        'match': '''(?x)
+          \\d{4}-\\d{2}-\\d{2}               # YYYY-MM-DD
+          (?:
+            (T)
+            \\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)? # HH:MM:SS.precision
+            (?:
+              (Z)
+              |
+              ([+-])\\d{2}:\\d{2}            # +/- HH:MM
+            )?
+          )?
+        '''
         'name': 'constant.numeric.date.toml'
         'captures':
           '1': 'name': 'keyword.other.time.toml'

--- a/grammars/toml.cson
+++ b/grammars/toml.cson
@@ -197,7 +197,7 @@
         'match': '''(?x)
           \\d{4}-\\d{2}-\\d{2}               # YYYY-MM-DD
           (?:
-            (T)
+            (T|[ ])                          # T or space
             \\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)? # HH:MM:SS.precision
             (?:
               (Z)

--- a/grammars/toml.cson
+++ b/grammars/toml.cson
@@ -194,6 +194,10 @@
         'name': 'constant.language.boolean.false.toml'
       }
       {
+        # Offset date-time, local date-time, local date
+        # https://github.com/toml-lang/toml#offset-date-time
+        # https://github.com/toml-lang/toml#local-date-time
+        # https://github.com/toml-lang/toml#local-date
         'match': '''(?x)
           \\d{4}-\\d{2}-\\d{2}               # YYYY-MM-DD
           (?:
@@ -208,11 +212,16 @@
         '''
         'name': 'constant.numeric.date.toml'
         'captures':
-          '1': 'name': 'keyword.other.time.toml'
-          '2': 'name': 'keyword.other.offset.toml'
-          '3': 'name': 'keyword.other.offset.toml'
+          '1':
+            'name': 'keyword.other.time.toml'
+          '2':
+            'name': 'keyword.other.offset.toml'
+          '3':
+            'name': 'keyword.other.offset.toml'
       }
       {
+        # Local time
+        # https://github.com/toml-lang/toml#local-time
         'match': '\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?'
         'name': 'constant.numeric.date.toml'
       }

--- a/grammars/toml.cson
+++ b/grammars/toml.cson
@@ -213,6 +213,10 @@
           '3': 'name': 'keyword.other.offset.toml'
       }
       {
+        'match': '\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?'
+        'name': 'constant.numeric.date.toml'
+      }
+      {
         'match': '[+-]?(0|[1-9]\\d*)(_\\d+)*((\\.\\d+)(_\\d+)*)?([eE][+-]?\\d+(_\\d+)*)?'
         'name': 'constant.numeric.toml'
       }

--- a/grammars/toml.cson
+++ b/grammars/toml.cson
@@ -194,21 +194,27 @@
         'name': 'constant.language.boolean.false.toml'
       }
       {
-        # Offset date-time, local date-time, local date
+        'include': '#date-time'
+      }
+      {
+        'match': '[+-]?(0|[1-9]\\d*)(_\\d+)*((\\.\\d+)(_\\d+)*)?([eE][+-]?\\d+(_\\d+)*)?'
+        'name': 'constant.numeric.toml'
+      }
+    ]
+  'date-time':
+    'patterns': [
+      {
+        # Offset date-time
         # https://github.com/toml-lang/toml#offset-date-time
-        # https://github.com/toml-lang/toml#local-date-time
-        # https://github.com/toml-lang/toml#local-date
         'match': '''(?x)
           \\d{4}-\\d{2}-\\d{2}               # YYYY-MM-DD
+          (T|[ ])                            # T or space
+          \\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?   # HH:MM:SS.precision
           (?:
-            (T|[ ])                          # T or space
-            \\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)? # HH:MM:SS.precision
-            (?:
-              (Z)
-              |
-              ([+-])\\d{2}:\\d{2}            # +/- HH:MM
-            )?
-          )?
+            (Z)
+            |
+            ([+-])\\d{2}:\\d{2}              # +/- HH:MM
+          )
         '''
         'name': 'constant.numeric.date.toml'
         'captures':
@@ -220,13 +226,28 @@
             'name': 'keyword.other.offset.toml'
       }
       {
+        # Local date-time
+        # https://github.com/toml-lang/toml#local-date-time
+        'match': '''(?x)
+          \\d{4}-\\d{2}-\\d{2}               # YYYY-MM-DD
+          (T|[ ])                            # T or space
+          \\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?   # HH:MM:SS.precision
+        '''
+        'name': 'constant.numeric.date.toml'
+        'captures':
+          '1':
+            'name': 'keyword.other.time.toml'
+      }
+      {
+        # Local date
+        # https://github.com/toml-lang/toml#local-date
+        'match': '\\d{4}-\\d{2}-\\d{2}'
+        'name': 'constant.numeric.date.toml'
+      }
+      {
         # Local time
         # https://github.com/toml-lang/toml#local-time
         'match': '\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?'
         'name': 'constant.numeric.date.toml'
-      }
-      {
-        'match': '[+-]?(0|[1-9]\\d*)(_\\d+)*((\\.\\d+)(_\\d+)*)?([eE][+-]?\\d+(_\\d+)*)?'
-        'name': 'constant.numeric.toml'
       }
     ]

--- a/spec/toml-spec.coffee
+++ b/spec/toml-spec.coffee
@@ -95,10 +95,16 @@ describe "TOML grammar", ->
       {tokens} = grammar.tokenizeLine("foo = #{float}")
       expect(tokens[4]).toEqual value: float, scopes: ["source.toml", "constant.numeric.toml"]
 
-  it "tokenizes dates", ->
+  it "tokenizes offset date-times", ->
     {tokens} = grammar.tokenizeLine("foo = 1979-05-27T07:32:00Z")
     expect(tokens[4]).toEqual value: "1979-05-27", scopes: ["source.toml", "constant.numeric.date.toml"]
     expect(tokens[5]).toEqual value: "T", scopes: ["source.toml", "constant.numeric.date.toml", "keyword.other.time.toml"]
+    expect(tokens[6]).toEqual value: "07:32:00", scopes: ["source.toml", "constant.numeric.date.toml"]
+    expect(tokens[7]).toEqual value: "Z", scopes: ["source.toml", "constant.numeric.date.toml", "keyword.other.offset.toml"]
+
+    {tokens} = grammar.tokenizeLine("foo = 1979-05-27 07:32:00Z")
+    expect(tokens[4]).toEqual value: "1979-05-27", scopes: ["source.toml", "constant.numeric.date.toml"]
+    expect(tokens[5]).toEqual value: " ", scopes: ["source.toml", "constant.numeric.date.toml", "keyword.other.time.toml"]
     expect(tokens[6]).toEqual value: "07:32:00", scopes: ["source.toml", "constant.numeric.date.toml"]
     expect(tokens[7]).toEqual value: "Z", scopes: ["source.toml", "constant.numeric.date.toml", "keyword.other.offset.toml"]
 
@@ -108,6 +114,20 @@ describe "TOML grammar", ->
     expect(tokens[6]).toEqual value: "00:32:00.999999", scopes: ["source.toml", "constant.numeric.date.toml"]
     expect(tokens[7]).toEqual value: "-", scopes: ["source.toml", "constant.numeric.date.toml", "keyword.other.offset.toml"]
     expect(tokens[8]).toEqual value: "07:00", scopes: ["source.toml", "constant.numeric.date.toml"]
+
+  it "tokenizes local date-times", ->
+    {tokens} = grammar.tokenizeLine("foo = 1979-05-27T00:32:00.999999")
+    expect(tokens[4]).toEqual value: "1979-05-27", scopes: ["source.toml", "constant.numeric.date.toml"]
+    expect(tokens[5]).toEqual value: "T", scopes: ["source.toml", "constant.numeric.date.toml", "keyword.other.time.toml"]
+    expect(tokens[6]).toEqual value: "00:32:00.999999", scopes: ["source.toml", "constant.numeric.date.toml"]
+
+  it "tokenizes local dates", ->
+    {tokens} = grammar.tokenizeLine("foo = 1979-05-27")
+    expect(tokens[4]).toEqual value: "1979-05-27", scopes: ["source.toml", "constant.numeric.date.toml"]
+
+  it "tokenizes local times", ->
+    {tokens} = grammar.tokenizeLine("foo = 00:32:00.999999")
+    expect(tokens[4]).toEqual value: "00:32:00.999999", scopes: ["source.toml", "constant.numeric.date.toml"]
 
   it "tokenizes tables", ->
     {tokens} = grammar.tokenizeLine("[table]")


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Adds compatibility with TOML 0.5's additions to date-time. Specifically, this PR ensures that the following elements from the TOML 0.5 changelog are properly supported:
* Rename Datetime to Offset Date-Time.
* Add Local Date-Time.
* Add Local Date.
* Add Local Time.
* Allow space (instead of T) to separate date and time in Date-Time.

### Alternate Designs

None.

### Benefits

Improved TOML 0.5 compatibility

### Possible Drawbacks

None.

### Applicable Issues

Fixes #22 