### PR TITLE
Support hex, octal, binary, inf, and nan

### DIFF
--- a/grammars/toml.cson
+++ b/grammars/toml.cson
@@ -197,8 +197,11 @@
         'include': '#date-time'
       }
       {
-        'match': '[+-]?(0|[1-9]\\d*)(_\\d+)*((\\.\\d+)(_\\d+)*)?([eE][+-]?\\d+(_\\d+)*)?'
-        'name': 'constant.numeric.toml'
+        'include': '#numbers'
+      }
+      {
+        'match': '.+'
+        'name': 'invalid.illegal.toml'
       }
     ]
   'date-time':
@@ -249,5 +252,43 @@
         # https://github.com/toml-lang/toml#local-time
         'match': '\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?'
         'name': 'constant.numeric.date.toml'
+      }
+    ]
+  'numbers':
+    # https://github.com/toml-lang/toml#integer
+    'patterns': [
+      {
+        # Handles decimal integers & floats
+        'match': '''(?x)
+          [+-]?                    # Optional +/-
+          (
+            0                      # Just a zero
+            |
+            [1-9](_?\\d)*          # Or a non-zero number (no leading zeros allowed)
+          )
+          (\\.\\d(_?\\d)*)?        # Optional fractional portion
+          ([eE][+-]?\\d(_?\\d)*)?  # Optional exponent
+          \\b
+        '''
+        'name': 'constant.numeric.toml'
+      }
+      {
+        'match': '[+-]?(inf|nan)\\b'
+        'name': 'constant.numeric.$1.toml'
+      }
+      {
+        # Hex
+        'match': '0x[0-9A-Fa-f](_?[0-9A-Fa-f])*\\b'
+        'name': 'constant.numeric.hex.toml'
+      }
+      {
+        # Octal
+        'match': '0o[0-7](_?[0-7])*\\b'
+        'name': 'constant.numeric.octal.toml'
+      }
+      {
+        # Binary
+        'match': '0b[01](_?[01])*\\b'
+        'name': 'constant.numeric.binary.toml'
       }
     ]


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Adds support for:
* Hex digits
* Octal digits
* Binary digits
* `inf`
* `nan`

Also highlights invalid values as invalid.

### Alternate Designs

None.

### Benefits

TOML 0.5 compatibility with integers & floats.

### Possible Drawbacks

The invalid highlighting may catch some things that should actually be valid. I added it so that the key/value matches would terminate correctly if nothing matched.

### Applicable Issues

Fixes #24