### PR TITLE
Allow whitespace after line continuation characters

### DIFF
--- a/grammars/toml.cson
+++ b/grammars/toml.cson
@@ -148,7 +148,8 @@
             'include': '#string-escapes'
           }
           {
-            'match': '\\\\$'
+            # Line continuation with backslashes
+            'match': '\\\\(?=\\s*$)'
             'name': 'constant.character.escape.toml'
           }
         ]


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

For TOML 0.5 compatibility.

### Alternate Designs

None.

### Benefits

Greater compatibility with TOML 0.5.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #25