### PR TITLE
Match common TOML file names

### DIFF
--- a/grammars/toml.cson
+++ b/grammars/toml.cson
@@ -1,6 +1,6 @@
 'name': 'TOML'
 'scopeName': 'source.toml'
-'fileTypes': ['toml']
+'fileTypes': ['toml', 'tml', 'Cargo.lock', 'Gopkg.lock', 'Pipfile', 'poetry.lock']
 'patterns': [
   {
     'include': '#comment'


### PR DESCRIPTION
### Description of the Change

This PR adds a few common TOML file names which this syntax can match.
The choice of names is inspired by the [sublime syntax definition](https://github.com/jasonwilliams/sublime_toml_highlighting/blob/6bfcc3c23619832a8343852dac2785e69503924c/TOML.sublime-syntax#L6), with the addition of the lock file used by [Poetry](https://python-poetry.org/) dependency manager (`poetry.lock`).

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Benefits

Less `CTRL+SHIFT+L` to change language
